### PR TITLE
chore: migrate to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "setup-xc-action",
   "version": "1.0.1",
   "description": "GitHub Action to setup Microchip XC compilers",
+  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build src/main.ts -m --no-source-map-register --license licenses.txt",

--- a/src/main.ts
+++ b/src/main.ts
@@ -289,6 +289,7 @@ export async function run(): Promise<void> {
 }
 
 // Only run if this file is being executed directly (not imported for testing)
-if (require.main === module) {
+const isMain = import.meta.url === new URL(process.argv[1], 'file:').href
+if (isMain) {
   run()
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -3,7 +3,8 @@
   "include": ["src/**/*", "__tests__/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
+    "rootDir": "."
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
-    "module": "commonjs",
-    "lib": ["ES2021"],
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2022"],
     "outDir": "./lib",
     "rootDir": "./src",
     "strict": true,
@@ -13,7 +14,8 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "verbatimModuleSyntax": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "__tests__"]


### PR DESCRIPTION
Unblocks all failing major dependency bumps (#11, #12, #14).

**Root cause**: `@actions/core` v3, `@actions/exec` v3, and `@actions/tool-cache` v4 all dropped CJS support — their `exports` field only exposes `"import"`. `@vercel/ncc` (webpack-based) can't bundle pure-ESM packages from a CJS context, causing the build step to fail for all three.

**Changes:**
- Add `"type": "module"` to `package.json`
- Update `tsconfig.json`: `module`/`moduleResolution` → `nodenext`, `target` → `ES2022`
- Replace `require.main === module` entry-point guard with `import.meta.url` equivalent
- `ncc` now compiles to ESM (`Compiling file index.js into ESM`)

All 49 tests pass, build succeeds, lint clean.